### PR TITLE
DEV: add github workflow for auto-update of app events data

### DIFF
--- a/.github/workflows/update-app-events-data
+++ b/.github/workflows/update-app-events-data
@@ -1,0 +1,52 @@
+name: Update App Events Data
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Run every Monday at 00:00 UTC
+  workflow_dispatch:     # Allow manual triggering
+
+jobs:
+  update-app-events-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout App Events Generator
+        uses: actions/checkout@v4
+
+      - name: Checkout Discourse Core
+        uses: actions/checkout@v4
+        with:
+          repository: discourse/discourse
+          path: 'discourse'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 21
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: package.json
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Create .env file
+        run: echo "DISCOURSE_CORE=./discourse" > .env
+
+      - name: Extract App Events
+        run: node scripts/extract_app_events.mjs
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Update app events data
+          title: Update App Events Data
+          body: |
+            This PR updates the app events data files:
+            - lib/app_events_docs_generator/app_events/app_events_details.json
+            - lib/app_events_docs_generator/app_events/event-ids.yml
+
+            The data was extracted from the latest Discourse core repository.
+          branch: dev-update-app-events-data
+          delete-branch: true

--- a/.github/workflows/update-app-events-data
+++ b/.github/workflows/update-app-events-data
@@ -37,6 +37,9 @@ jobs:
       - name: Extract App Events
         run: node scripts/extract_app_events.mjs
 
+      - name: Generate App Events Details Doc
+        run: node scripts/create_app_events_doc_markdown.mjs
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -46,6 +49,7 @@ jobs:
             This PR updates the app events data files:
             - lib/app_events_docs_generator/app_events/app_events_details.json
             - lib/app_events_docs_generator/app_events/event-ids.yml
+            - lib/app_events_docs_generator/app_events/app_events_docs.md
 
             The data was extracted from the latest Discourse core repository.
           branch: dev-update-app-events-data


### PR DESCRIPTION
Currently, we manually run a script to update the data files in this repo before using that to update the docs housed in https://github.com/discourse/discourse-developer-docs.

This workflow automates that to a weekly PR cadence - which will look a bit like https://github.com/discourse/discourse-app-events-docs-generator/pull/3.

I'll add a different workflow to also raise a PR to discourse-developer-docs with the final `.md` file. 